### PR TITLE
Fix the issue of Username Token not getting set when there are no other headers present in the SOAP envelop

### DIFF
--- a/soap/soap_utils.bal
+++ b/soap/soap_utils.bal
@@ -158,19 +158,22 @@ function createSoapHeader(SoapRequest request, SoapVersion soapVersion) returns 
         }
         headerElement = headersXML;
     }
-
-    if (headerElement is xml) {
-        if (request["requestTo"] is string) {
-            headerElement += getWSAddressingHeaders(request);
+    if (request["requestTo"] is string) {
+        if (headerElement is ()) {
+            headerElement = getWSAddressingHeaders(request);
+        } else {
+            headerElement = headerElement + getWSAddressingHeaders(request);
         }
-
-        if (request["username"] is string) {
-            headerElement += getWSSecreUsernameTokenHeaders(request);
+    }
+    if (request["username"] is string) {
+        if (headerElement is ()) {
+            headerElement = getWSSecreUsernameTokenHeaders(request);
+        } else {
+            headerElement = headerElement + getWSSecreUsernameTokenHeaders(request);
         }
-
-        if (!headerElement.isEmpty()) {
-            headersRoot.setChildren(headerElement);
-        }
+    }
+    if (headerElement is xml && !headerElement.isEmpty()) {
+        headersRoot.setChildren(headerElement);
     }
     return headersRoot;
 }

--- a/soap/tests/test.bal
+++ b/soap/tests/test.bal
@@ -17,7 +17,7 @@
 import ballerina/log;
 import ballerina/test;
 
-Client soapClient = new("http://localhost:9000");
+Client soapTestClient = new("http://localhost:9000");
 
 @test:Config
 function testSendReceive() {
@@ -34,7 +34,7 @@ function testSendReceive() {
         payload: body
     };
 
-    var response = soapClient->sendReceive("/services/SimpleStockQuoteService", soapRequest);
+    var response = soapTestClient->sendReceive("/services/SimpleStockQuoteService", soapRequest);
     if (response is SoapResponse) {
         test:assertEquals(response.soapVersion, SOAP11);
     } else {

--- a/soap/tests/test.bal
+++ b/soap/tests/test.bal
@@ -17,7 +17,7 @@
 import ballerina/log;
 import ballerina/test;
 
-Client soapTestClient = new("http://localhost:9000");
+Client soapClient = new("http://localhost:9000");
 
 @test:Config
 function testSendReceive() {
@@ -34,7 +34,7 @@ function testSendReceive() {
         payload: body
     };
 
-    var response = soapTestClient->sendReceive("/services/SimpleStockQuoteService", soapRequest);
+    var response = soapClient->sendReceive("/services/SimpleStockQuoteService", soapRequest);
     if (response is SoapResponse) {
         test:assertEquals(response.soapVersion, SOAP11);
     } else {


### PR DESCRIPTION
## Purpose
Fix the issue : https://github.com/wso2-ballerina/module-soap/issues/36